### PR TITLE
Use numpy 1.19.5 for mypy compatibility

### DIFF
--- a/bdd100k/eval/mot.py
+++ b/bdd100k/eval/mot.py
@@ -100,7 +100,7 @@ def acc_single_video(
                 )
             if gt_ignores.shape[0] > 0:
                 # 1. assign gt and preds
-                fps = np.ones(pred_bboxes_c.shape[0]).astype(np.bool)
+                fps = np.ones(pred_bboxes_c.shape[0]).astype(np.bool8)
                 le, ri = mm.lap.linear_sum_assignment(distances)
                 for m, n in zip(le, ri):
                     if not np.isfinite(distances[m, n]):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ joblib
 matplotlib
 motmetrics
 mypy
-numpy>=1.19
+numpy==1.19.5
 pandas
 pillow
 pycocotools

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,8 @@ disallow_any_explicit = True
 disallow_any_generics = True
 disallow_subclassing_any = True
 
+# plugins = numpy.typing.mypy_plugin
+
 [mypy-psutil]
 
 ignore_missing_imports = True


### PR DESCRIPTION
`numpy` `1.20` causes some unnecessary typing errors. We shall upgrade to `1.21.0` and use numpy mypy plugin (https://numpy.org/devdocs/reference/typing.html) when it is available.