### PR TITLE
make it suitable for codalab

### DIFF
--- a/bdd100k/eval/mot.py
+++ b/bdd100k/eval/mot.py
@@ -217,7 +217,7 @@ def render_results(
     logger.info(strsummary)
 
     outputs: DictAny = dict()
-    for i, item in enumerate(items[len(CLASSES) :], len(CLASSES)):
+    for i, item in enumerate(items):
         outputs[item] = dict()
         for j, metric in enumerate(METRIC_MAPS.values()):
             outputs[item][metric] = summaries[i][j]


### PR DESCRIPTION
Make it suitable for the usage of codalab.
Previously only metrics of supercategories will be returned.
Now, all categories' metrics are returned