### PR TITLE
Add missing --nproc argument for label.from_coco

### DIFF
--- a/bdd100k/label/from_coco.py
+++ b/bdd100k/label/from_coco.py
@@ -17,6 +17,12 @@ def parse_arguments() -> argparse.Namespace:
         "-o",
         help="path to save bdd formatted label file",
     )
+    parser.add_argument(
+        "--nproc",
+        type=int,
+        default=4,
+        help="number of processes for evaluation",
+    )
     return parser.parse_args()
 
 


### PR DESCRIPTION
Adds required --nproc argument for conversion from coco. 
Code errors otherwise with: `AttributeError: 'Namespace' object has no attribute 'nproc'`