### PR TITLE
Fix an error when run evaluation for segmentation cause by numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ joblib
 matplotlib
 motmetrics
 mypy
-numpy==1.19.5
+numpy>=1.20
 pandas
 pillow
 pycocotools

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
         "joblib",
         "matplotlib",
         "motmetrics",
-        "numpy==1.19.5",
+        "numpy>=1.20",
         "pandas",
         "pillow",
         "pycocotools",


### PR DESCRIPTION
ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 88 from C header, got 80 from PyObject
