### PR TITLE
fix bdd100k config loading

### DIFF
--- a/bdd100k/common/utils.py
+++ b/bdd100k/common/utils.py
@@ -1,6 +1,5 @@
 """Util functions."""
 
-import inspect
 import os
 import os.path as osp
 from itertools import groupby
@@ -73,7 +72,7 @@ def load_bdd100k_config(cfg_path: str) -> BDD100KConfig:
     """Load a task-specific config."""
     if not cfg_path.endswith("toml"):
         cfg_path = osp.join(
-            osp.split(osp.dirname(osp.abspath(inspect.stack()[1][1])))[0],
+            osp.split(osp.dirname(osp.abspath(__file__)))[0],
             "configs",
             cfg_path + ".toml",
         )

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,15 @@ setuptools.setup(
         "tabulate",
         "tqdm",
     ],
-    package_data={"bdd100k": ["common/configs.toml", "py.typed"]},
+    package_data={
+        "bdd100k": [
+            "configs/det.toml",
+            "configs/ins_seg.toml",
+            "configs/sem_seg.toml",
+            "configs/box_track.toml",
+            "configs/seg_track.toml",
+            "py.typed",
+        ]
+    },
     include_package_data=True,
 )


### PR DESCRIPTION
inspect returns a wrong path, therefore replace it with `osp.dirname(osp.abspath(__file__))`.