### PR TITLE
fix bugs in to_scalabel

### DIFF
--- a/bdd100k/label/testcases/example_ignore_annotation.json
+++ b/bdd100k/label/testcases/example_ignore_annotation.json
@@ -1,1 +1,45 @@
-[{"name": "00091078-875c1f73-0000166.jpg", "videoName": "00091078-875c1f73","frameIndex": 0, "labels": [ {"id": "00109430", "category": "other person", "attributes": {"Occluded": true, "Truncated": false, "crowd": false}, "box2d": {"x1": 1068.051474568342, "x2": 1108.7226195720182, "y1": 362.7665840944419, "y2": 466.2931350128905}}]}, {"name": "00091078-875c1f73-0000167.jpg", "videoName": "00091078-875c1f73","frameIndex": 1, "labels": null}]
+[
+  {
+    "name": "00091078-875c1f73-0000166.jpg",
+    "videoName": "00091078-875c1f73",
+    "frameIndex": 0,
+    "labels": [
+      {
+        "id": "00109430",
+        "category": "other person",
+        "attributes": {
+          "Occluded": true,
+          "Truncated": false,
+          "crowd": false
+        },
+        "box2d": {
+          "x1": 1068.051474568342,
+          "x2": 1108.7226195720182,
+          "y1": 362.7665840944419,
+          "y2": 466.2931350128905
+        }
+      },
+      {
+        "id": "00109431",
+        "category": "person",
+        "attributes": {
+          "Occluded": true,
+          "Truncated": false,
+          "crowd": false
+        },
+        "box2d": {
+          "x1": 68.051474568342,
+          "x2": 108.7226195720182,
+          "y1": 301.7665840944419,
+          "y2": 426.2931350128905
+        }
+      }
+    ]
+  },
+  {
+    "name": "00091078-875c1f73-0000167.jpg",
+    "videoName": "00091078-875c1f73",
+    "frameIndex": 1,
+    "labels": null
+  }
+]

--- a/bdd100k/label/to_scalabel.py
+++ b/bdd100k/label/to_scalabel.py
@@ -40,6 +40,7 @@ def deal_bdd100k_category(
             label.category = category_name
             result = label
     else:
+        label.category = category_name
         result = label
     return result
 

--- a/bdd100k/label/to_scalabel_test.py
+++ b/bdd100k/label/to_scalabel_test.py
@@ -24,7 +24,9 @@ class TestBDD100KToScalabel(unittest.TestCase):
         self.assertEqual(len(new_frames), 2)
         labels = new_frames[0].labels
         assert labels is not None
+        self.assertEqual(len(labels), 2)
         self.assertEqual(labels[0].category, "pedestrian")
+        self.assertEqual(labels[1].category, "pedestrian")
         assert labels[0].attributes is not None
         self.assertTrue(labels[0].attributes[IGNORED])
         self.assertEqual(new_frames[1].labels, None)
@@ -33,4 +35,5 @@ class TestBDD100KToScalabel(unittest.TestCase):
         new_frames = bdd100k_to_scalabel(frames, bdd100k_config)
         labels = new_frames[0].labels
         assert labels is not None
-        self.assertEqual(len(labels), 0)
+        self.assertEqual(len(labels), 1)
+        self.assertEqual(labels[0].category, "pedestrian")


### PR DESCRIPTION
Bug:
in to_scalabel, category_name was mapped from legacy names to new names but is not assigned to label.category.