### PR TITLE
switch to https when cloning scalabel during install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ tabulate
 toml
 tqdm
 
-git+git://github.com/scalabel/scalabel.git
+git+https://github.com/scalabel/scalabel.git


### PR DESCRIPTION
due to: https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git